### PR TITLE
Add requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,11 @@
+pydub
+tk
+pedalboard
+pydub
+replicate
+midiutil
+soundfile
+openai
+numpy
+pygame
+


### PR DESCRIPTION
Not a pythonista, but I believe its a convention to use this `requirements.txt`

and then run: `pip install -r requirements.txt`